### PR TITLE
Allow to print the Window object

### DIFF
--- a/extension.go
+++ b/extension.go
@@ -34,7 +34,7 @@ func (e *Extension) GetViews(fetchProperties Object) []Window {
 	windowObjs := e.o.Call("getViews", fetchProperties)
 	for i := 0; i < windowObjs.Length(); i++ {
 		window := windowObjs.Index(i)
-		windows = append(windows, Window{Object: *window})
+		windows = append(windows, Window{Object: window})
 	}
 	return windows
 }
@@ -42,7 +42,7 @@ func (e *Extension) GetViews(fetchProperties Object) []Window {
 // GetBackgroundPage returns the JavaScript 'window' object for the background page running inside
 // the current extension. Returns null if the extension has no background page.
 func (e *Extension) GetBackgroundPage() Window {
-	return Window{Object: *e.o.Call("getBackgroundPage")}
+	return Window{Object: e.o.Call("getBackgroundPage")}
 }
 
 // GetExtensionTabs returns an array of the JavaScript 'window' objects for each of the tabs running inside
@@ -52,7 +52,7 @@ func (e *Extension) GetExtensionTabs(windowId int) []Window {
 	windowObjs := e.o.Call("getExtensionTabs", windowId)
 	for i := 0; i < windowObjs.Length(); i++ {
 		window := windowObjs.Index(i)
-		windows = append(windows, Window{Object: *window})
+		windows = append(windows, Window{Object: window})
 	}
 	return windows
 }

--- a/tabs.go
+++ b/tabs.go
@@ -212,7 +212,7 @@ func (t *Tabs) OnRemoved(callback func(tabId int, removeInfo Object)) {
 
 // OnReplaced fired when a tab is replaced with another tab due to prerendering or instant.
 func (t *Tabs) OnReplaced(callback func(addedTabId int, removedTabId int)) {
-	t.o.Get("OnReplaced").Call("addListener", callback)
+	t.o.Get("onReplaced").Call("addListener", callback)
 }
 
 // OnZoomChange fired when a tab is zoomed.

--- a/windows.go
+++ b/windows.go
@@ -92,10 +92,10 @@ func (w *Windows) OnRemoved(callback func(windowId int)) {
 	w.o.Get("onRemoved").Call("addListener", callback)
 }
 
-// onFocusChanged fired when the currently focused window changes.
+// OnFocusChanged fired when the currently focused window changes.
 // Will be chrome.windows.WINDOW_ID_NONE if all chrome windows have lost focus.
 // Note: On some Linux window managers, WINDOW_ID_NONE will always be sent immediately
 // preceding a switch from one chrome window to another.
-func (w *Windows) onFocusChanged(callback func(windowId int)) {
+func (w *Windows) OnFocusChanged(callback func(windowId int)) {
 	w.o.Get("onFocusChanged").Call("addListener", callback)
 }

--- a/windows.go
+++ b/windows.go
@@ -23,7 +23,7 @@ func NewWindows(windowsObj *js.Object) *Windows {
  */
 
 type Window struct {
-	js.Object
+	*js.Object
 	Id          int    `js:"id"`
 	Focused     bool   `js:"focused"`
 	Top         int    `js:"top"`


### PR DESCRIPTION
The js.Object reference is now similar to the Tab object.

It was failing with:

    cannot internalize js.Object, use *js.Object instead